### PR TITLE
Disconnect Todoist button

### DIFF
--- a/app/controllers/todo_apps_controller.rb
+++ b/app/controllers/todo_apps_controller.rb
@@ -29,9 +29,11 @@ class TodoAppsController < ApplicationController
 
   def disconnect
     if Todoist.connected?(current_user)
+      @button_url = todo_apps_disconnect_todoist_path
       @button_text = "<i class='fa fa-trash'></i> Disconnect Todoist"
       @button_class = "button"
     else
+      @button_url = ""
       @button_text = "<i class='fa fa-ban'></i> Todoist not connected"
       @button_class = "button disabled"
     end

--- a/app/views/todo_apps/disconnect.html.slim
+++ b/app/views/todo_apps/disconnect.html.slim
@@ -2,4 +2,4 @@ main.page
 
   h1 Disconnect
   p Too many connections? You can disconnect an app here.
-  = link_to raw(@button_text), todo_apps_disconnect_todoist_path, class: @button_class
+  = link_to raw(@button_text), @button_url, class: @button_class


### PR DESCRIPTION
Disable the button when no Todoist is connected. The URL is empty.
